### PR TITLE
fix(colors): inherit missing accent variants from base overrides

### DIFF
--- a/lua/aether/colors/init.lua
+++ b/lua/aether/colors/init.lua
@@ -80,6 +80,24 @@ function M.setup(opts)
   -- Allow users to override colors via opts.colors table (base16 style)
   if opts.colors and next(opts.colors) then
     colors = vim.tbl_deep_extend("force", colors, opts.colors)
+
+    -- If a base accent is overridden without its variants, inherit variants.
+    local fallback_variants = {
+      green = { "green1", "green2" },
+      blue = { "blue1", "blue2" },
+      red = { "red1" },
+      magenta = { "magenta2" },
+    }
+
+    for base, variants in pairs(fallback_variants) do
+      if opts.colors[base] then
+        for _, variant in ipairs(variants) do
+          if not opts.colors[variant] then
+            colors[variant] = colors[base]
+          end
+        end
+      end
+    end
     
     -- Map base16 colors to semantic names AND all variants if base16 colors were provided
     if opts.colors.base00 then 


### PR DESCRIPTION
## Summary

  This PR fixes lime-green @property/attribute highlighting when users override base accent colors (like green) but do not explicitly override variant shades (green1, green2).

  The issue showed up most clearly in CSS / GTK CSS / HTML where some tokens still rendered as default lime (#a6e22e) even with a custom palette.

  ## Root Cause

  Aether Treesitter groups map:

  - @property -> c.green1
  - @tag.attribute -> @property

  So if config overrides only green, but leaves green1 unset, @property still uses default green1 (#a6e22e).

  ## Fix

  In lua/aether/colors/init.lua, after merging opts.colors, this PR adds a table-driven fallback that inherits missing
  variant colors from their overridden base color.

  Example behavior:

  - if green is set and green1/green2 are not set -> green1/green2 inherit green
  - same pattern for blue -> blue1/blue2, red -> red1, magenta -> magenta2

  This keeps variant-dependent highlight groups aligned with user overrides while preserving explicit variant overrides
  when provided.

  ## Why This Approach

  - Minimal, localized change in color setup
  - Backward-compatible for normal palette-driven usage
  - No generator/template migration required
  - Prevents this same mismatch class for other base/variant accents

  ## Tradeoff

  This now keeps related colors in sync automatically.
  If you want a shade like green1 or blue2 to be different, just set it directly in opts.colors.

  ## Validation

  Validated in a live Neovim setup by:

  1. Applying this branch
  2. Opening CSS/HTML files
  3. Checking:
      - :verbose hi @property
      - :verbose hi @tag.attribute

  Result: @property now follows the overridden green family instead of falling back to default lime.